### PR TITLE
add utf8 test

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -241,6 +241,18 @@ fn ambiguous_router() {
 }
 
 #[test]
+fn utf8_router() {
+    let mut router = Router::new();
+
+    router.add("/고양이/:어디", "어디".to_string());
+
+    let id = router.recognize("/고양이/여기!").unwrap();
+
+    assert_eq!(*id.handler, "어디".to_string());
+    assert_eq!(id.params, params("어디", "여기!"));
+}
+
+#[test]
 fn ambiguous_router_b() {
     let mut router = Router::new();
 


### PR DESCRIPTION
```
failures:
---- utf8_router stdout ---- 
        task 'utf8_router' failed at 'index 4 and/or 17 in `고양이/여기!` do not lie on character boundary', /home/rustbuild/src/rust-buildbot/slave/nightly-linux/build/src/libcore/str.rs:1834
failures:
    utf8_router
test result: FAILED. 17 passed; 1 failed; 4 ignored; 0 measured
```
