### PR TITLE
Added Params::keys method

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,6 +75,10 @@ impl Params {
     pub fn find(&self, key: &str) -> Option<&str> {
         self.map.get(key).map(|s| &s[..])
     }
+    
+    pub fn keys(&self) -> Vec<&String> {
+    	self.map.keys().collect()
+    }
 }
 
 impl<'a> Index<&'a str> for Params {


### PR DESCRIPTION
Added Params::keys method to help routers built on top of the route-recognizer handle all of the params. It is really helpful if you want to replace all of the captured parameters somewhere else.
